### PR TITLE
Fix some typos in comments and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For date display, you can use the timeago jQuery plugin (display timespans inste
 If you have access to a cover service API, set the setting in *config.php* to ``true``, and configure your service in *sys/class.ListJournals.php* (``getCover()``).
 By default, cover images will be loaded from *img/*, if there exists an image file named after the ISSN (e.g. *0123-4567.png*). If not, a placeholder will be used (configure in *config.php*).
 
-All image content is preloaded from the input file. To make things load faster (e.g. on slow bandwith), the jQuery plugin unveil.js is loaded by default. The preload image is in the *img/*-directory and is called *lazyloader.gif*. The placeholder image must be set in the *src* attribute of the journal listing. The actual cover image must be placed in the attribute *data-src*. See the listing part in index.php.
+All image content is preloaded from the input file. To make things load faster (e.g. on slow bandwidth), the jQuery plugin unveil.js is loaded by default. The preload image is in the *img/*-directory and is called *lazyloader.gif*. The placeholder image must be set in the *src* attribute of the journal listing. The actual cover image must be placed in the attribute *data-src*. See the listing part in index.php.
 
 ## PHP Classes
 
@@ -308,7 +308,7 @@ Filters will show up in the heading section of *index.php*, and their behavior o
 ## Export options
 
 Export for citation management software currently is very basic. To be
-able to digest heterogenous data from different sources (CrossRef,
+able to digest heterogeneous data from different sources (CrossRef,
 JournalTOCs...), some essential metadata fields should be normalized already
  in the TOC snippet (*ajax/get...*). 
 

--- a/config-default.php
+++ b/config-default.php
@@ -56,7 +56,7 @@ $cfg->api->jt = new stdClass();
  * setting requries are JournalToc (JT) premium account.
  *
  * Note: You can get quite a lot without a JT premium account running
- * services/getJournalInfos.php (preferrably on a daily basis). But you still need a
+ * services/getJournalInfos.php (preferably on a daily basis). But you still need a
  * standard account.
  */
 $cfg->api->all->articleLink = true; // Should articles in fetched toc's be clickable links? Set false if not.
@@ -66,7 +66,7 @@ $cfg->api->jt->account  = '';       // The mail you are registered with at Journ
 $cfg->api->jt->premium  = false;    // Premium: Set to true if you got a premium account
 $cfg->api->jt->upd_show = false;    // Premium: Uses infos from outfile. Slows page loading down
 $cfg->api->jt->updates  = 'http://www.journaltocs.ac.uk/api/journals/latest_updates?user='; // Premium: Update URL
-$cfg->api->jt->outfile  = 'input/updates.json.txt';   // Premium: The file the updates are saved to temporarily. You'll have to run services/getLatestJournals.php regularily
+$cfg->api->jt->outfile  = 'input/updates.json.txt';   // Premium: The file the updates are saved to temporarily. You'll have to run services/getLatestJournals.php regularly
 
 
 
@@ -142,7 +142,7 @@ $cfg->csv_col->tags          = 16;  // Optional/Auto. Got some subject indexing?
 
 $cfg->filter = array();
 /**
- * In the colum defined by $cfg->csv_col->filter you write a shorthand code for
+ * In the column defined by $cfg->csv_col->filter you write a shorthand code for
  * the filter. Here you map that shorthand code to some human readable name.
  *
  * Just to clarify why the value of that column is not taken directly: The
@@ -164,7 +164,7 @@ $cfg->filter['wir'] = __('Yet another filter');
 $cfg->covers = new stdClass();
 /**
  * Put covers into the img folder. The name must be the issn set the column
- * specified for $cfg->csv_col->issn. The extention might be jpg, gif or png.
+ * specified for $cfg->csv_col->issn. The extension might be jpg, gif or png.
  *
  * There are rumours that cover api's for journals exist, but no free service
  * is known. So, it's up to you how you get the covers (ask vendor, journal

--- a/sys/class.CheckoutActions.php
+++ b/sys/class.CheckoutActions.php
@@ -178,7 +178,7 @@ class CheckoutActions
             while (($data = fgetcsv($handle, 1000, "#")) !== FALSE) {
             
                 /* strip our csv again - ugly-ugly but the alternative is adding functions to simpleCart.js (only limited fields available) */
-                /* BEWARE! This will not match all data (too heterogenous), but at least some of it */
+                /* BEWARE! This will not match all data (too heterogeneous), but at least some of it */
                 preg_match('/[^:]*/',$data[0],$au); /* author */
                 preg_match('/^.*?:\s(.*)/',$data[0],$ti); /* title */
                 preg_match('/source:\s([^,]*)/',$data[2],$jo); /* journal title */

--- a/sys/class.ListJournals.php
+++ b/sys/class.ListJournals.php
@@ -16,7 +16,7 @@
  * - Maybe fetch more infos per http://amsl.technology/issn-resolver/
  * -- Maybe automatically fetch publish frequency and create "paging" for journals?
  * - Create some kind of (daily) cached version of the front page so it loads
- *   faster (not having to generate everything everytime)
+ *   faster (not having to generate everything every time)
  */
 class ListJournals
 {
@@ -43,7 +43,7 @@ class ListJournals
   /**
    * @brief   Load settings from config.php and set properties
    *
-   * @note    The mapping is unecessary, but maybe improves readability above
+   * @note    The mapping is unnecessary, but maybe improves readability above
    *          just $this->cfg = $cfg.
    *
    * @return \b void

--- a/sys/class.getJournalInfos.php
+++ b/sys/class.getJournalInfos.php
@@ -469,7 +469,7 @@ class GetJournalInfos {
    *          "Volume 13, Issue 1, Page 518-536, January 2014" in some Description
    *
    * @todo
-   * - <content:encoded> provides a formated reference - maybe just split()?
+   * - <content:encoded> provides a formatted reference - maybe just split()?
    * - <dc:identifier> DOIs! ("DOI 10.1002/adma.201400310") - not always that
    *   nice. Also always/often in <item rdf:about="xxx">?
    * - ignore titles like "Masthead: (Adv. Mater. 24/2014)",
@@ -642,7 +642,7 @@ class GetJournalInfos {
    * @todo
    * - IMPORTANT: Umm, $this->journal_row['date'] = $current_date is a bad idea?
    *   Is this column used somewhere for checks?!?
-   * - Maybe add (guess) update frequency to prevent unecessary checks?
+   * - Maybe add (guess) update frequency to prevent unnecessary checks?
    * - Just comparing year/vol/issue should be sufficient, a closer look doesn't
    *   make sense?
    *


### PR DESCRIPTION
All of them were found and fixed using CodeSpell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>