### PR TITLE
Workaround to lazy load images (again). Also: only lazy load covers.

### DIFF
--- a/js/local/conduit.js
+++ b/js/local/conduit.js
@@ -32,7 +32,8 @@ function updateCartItemWithCitation( item, cit, cart ) {
 $(document).ready(function() {
 
     /* run unveil plugin on page load */
-    $("img").unveil();
+    setTimeout(function() {$("img.getTOC").unveil();}, 1);
+    //$("img").unveil();
 
     /* Alphabet button bar */
     /* currently for grid view only */


### PR DESCRIPTION
For some reason otherwise everything is loaded at once. Used workaround described here: https://stackoverflow.com/questions/16823802/lazyload-loading-all-images-on-load