### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Try here: http://www.coll.mpg.de/bib/jtdemo-public/
 
 # Dependencies
 - PHP 5.3 ([http://www.php.net])
+- php5-curl module ([http://php.net/manual/de/book.curl.php])
 - API key for JournalTocs ([http://www.journaltocs.ac.uk])
 
 # Wiki


### PR DESCRIPTION
"adding php5-curl as a dependency, since it is NOT part of the default LAMP stack."