### PR TITLE
Pr bugfixing 04

### DIFF
--- a/js/local/conduit.js
+++ b/js/local/conduit.js
@@ -121,7 +121,7 @@ function fetch_metabuttons_toc(issn, para_caching, para_pubdate) {
  */
 function start_screensaver(srcDiv) {
     var srcDiv = srcDiv || '#screensaver';
-    var s_saver, clear_basket;
+    var s_saver, clear_basket, reset_screen;
     // Get user set values from data elements of divs
     var usr_clear_basket         = $('#cartPopover').attr('data-clearSeconds') * 1000;
     var usr_screensaver_activate = $(srcDiv).attr('data-activateSeconds') * 1000;
@@ -138,6 +138,25 @@ function start_screensaver(srcDiv) {
         // clear old timeouts
 		clearTimeout(s_saver);
 		clearTimeout(clear_basket);
+		clearTimeout(reset_screen);
+
+        // Reset stuff before 2 seconds before either basket or screensaver
+        // fires (whatever comes first)
+        // @todo: Does nearly the same as $('a.filter').click(function(){} - refactor
+        reset_timer = (Math.min(usr_clear_basket, usr_screensaver_activate)) - 2000;
+        reset_screen = setTimeout(function(){
+            // go to top first
+            $('html, body').animate({ scrollTop: 0 }, 'slow');
+    		// remove any open modal
+    		$('.reveal-modal').foundation('reveal', 'close');
+    		// reset alphabet
+    		$('#alphabet li a').show();
+            // Disable filters (if any are still set)
+            $('.listitem').show();
+            $('#filterPanel').fadeOut();
+            // Clear search field
+            $('#search').val('');
+        }, reset_timer);
 
         clear_basket = setTimeout(function(){
             if (usr_clear_basket > 0) simpleCart.empty();
@@ -147,7 +166,6 @@ function start_screensaver(srcDiv) {
 
         if (usr_screensaver_activate == 0) return; // screensaver is completely disabled
         s_saver = setTimeout(function(){
-            $('html').scrollTop(0); // go to top first
             // Use animation?
             if (usr_screensaver_speed != 0) {
                 animateDiv();

--- a/sys/php-gettext/gettext.php
+++ b/sys/php-gettext/gettext.php
@@ -98,7 +98,7 @@ class gettext_reader {
    * @param object Reader the StreamReader object
    * @param boolean enable_cache Enable or disable caching of strings (default on)
    */
-  function gettext_reader($Reader, $enable_cache = true) {
+  function __construct($Reader, $enable_cache = true) {
     // If there isn't a StreamReader, turn on short circuit mode.
     if (! $Reader || isset($Reader->error) ) {
       $this->short_circuit = true;

--- a/sys/php-gettext/streams.php
+++ b/sys/php-gettext/streams.php
@@ -49,7 +49,7 @@ class StringReader {
   var $_pos;
   var $_str;
 
-  function StringReader($str='') {
+  function __construct($str='') {
     $this->_str = $str;
     $this->_pos = 0;
   }
@@ -86,7 +86,7 @@ class FileReader {
   var $_fd;
   var $_length;
 
-  function FileReader($filename) {
+  function __construct($filename) {
     if (file_exists($filename)) {
 
       $this->_length=filesize($filename);
@@ -143,7 +143,7 @@ class FileReader {
 // Preloads entire file in memory first, then creates a StringReader
 // over it (it assumes knowledge of StringReader internals)
 class CachedFileReader extends StringReader {
-  function CachedFileReader($filename) {
+  function __construct($filename) {
     if (file_exists($filename)) {
 
       $length=filesize($filename);


### PR DESCRIPTION
Ok, last pr - maybe :)

Because some people got irritated if filers were set after touching the screen, now everything is reset before starting the screensaver. Works in FF, Crome and IE11 - at least I hope, I didn't break anything. 

Only thing is (but that was true before) I think the scrolling resets the timer for the screensaver & the basket clearing - well, at least it "should" come up right after the scrolling, but it seems to take a whole new timeout cycle. But I don't get why...