### PR TITLE
Fix some typos in comments and strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ data/*
 config.php
 sys/class.GetUsers.php
 
-# Some exclusions, so the folders always are created, even if initally empty
+# Some exclusions, so the folders always are created, even if initially empty
 !*.gitkeep
 !admin/upgrade/history/.gitkeep
 !admin/upgrade/versions/.gitkeep

--- a/admin/.htaccess.sample
+++ b/admin/.htaccess.sample
@@ -1,4 +1,4 @@
-# JournalTouch currently has no real admin area. For now you should limit acces
+# JournalTouch currently has no real admin area. For now you should limit access
 # to this folder by ip.
 
 #require ip 127.0.0.1

--- a/admin/covers.php
+++ b/admin/covers.php
@@ -69,7 +69,7 @@ $max_show = 100;
 $entry_start = (isset($_GET['start'])) ? $_GET['start'] : 1;
 
 // Get available journals images (manual and api)
-// Merge everthing in a big array with issn as key
+// Merge everything in a big array with issn as key
 /*
     [1572-9125] => Array(
         [journal] => BIT. Numerical mathematics

--- a/admin/services/class.GetCover.php
+++ b/admin/services/class.GetCover.php
@@ -202,7 +202,7 @@ class GetCover {
         // the directlink if provided
         if (!$status && $directlink) {
             $status = _save_image($directlink);
-            $this->log .= ($status) ? '&gt; Sucessfully downloaded via provided direct download link<br>' : '&gt; Failed downloading via provided direct download link<br>';
+            $this->log .= ($status) ? '&gt; Successfully downloaded via provided direct download link<br>' : '&gt; Failed downloading via provided direct download link<br>';
         }
 
 
@@ -210,7 +210,7 @@ class GetCover {
         // If a custom url was provided, try this first
         if (!$status && $this->custom_api_url) {
             $status = get_user_cover_api();
-            $this->log .= ($status) ? '&gt; Sucessfully downloaded via user cover api<br>' : '&gt; Failed downloading via user cover api<br>';
+            $this->log .= ($status) ? '&gt; Successfully downloaded via user cover api<br>' : '&gt; Failed downloading via user cover api<br>';
         }
 
         // Got no cover yet, try specific publisher, if provided
@@ -219,7 +219,7 @@ class GetCover {
             foreach ($this->src_publisher AS $publisher => $enabled) {
                 if ($this->publisher == strtolower($publisher) && $enabled == 1) {
                     $status = call_user_func(array($this, 'get_publisher_'.$publisher));
-                    $this->log .= ($status) ? '&gt; Sucessfully downloaded cover from publisher '.$publisher.'<br>' : '&gt; Failed downloading cover from publisher '.$publisher.'<br>';
+                    $this->log .= ($status) ? '&gt; Successfully downloaded cover from publisher '.$publisher.'<br>' : '&gt; Failed downloading cover from publisher '.$publisher.'<br>';
                     if ($status) break;
                 }
             }
@@ -230,7 +230,7 @@ class GetCover {
             foreach ($this->src_genric AS $source => $enabled) {
                 if ($enabled == 1) {
                     $status = call_user_func(array($this, 'get_generic_'.$source));
-                    $this->log .= ($status) ? '&gt; Sucessfully downloaded cover from generic: '.$source.'<br>' : '&gt; Failed downloading cover from generic: '.$source.'<br>';
+                    $this->log .= ($status) ? '&gt; Successfully downloaded cover from generic: '.$source.'<br>' : '&gt; Failed downloading cover from generic: '.$source.'<br>';
                     if ($status) break;
                 }
             }

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -172,7 +172,7 @@ function frm_input_translatable($name, $value, $label = '', $aria = '', $textare
             $frm_value  = $value->$language;
         }
         // But sometimes using arrays can't really be prevented without getting
-        // really ugly. The one and only case currenly: the filters (multidimensional)
+        // really ugly. The one and only case currently: the filters (multidimensional)
         elseif (is_array($value)) {
             $frm_value  = (isset($value[$language])) ? $value[$language] : '';
         } else {
@@ -458,7 +458,7 @@ function frm_input_translatable($name, $value, $label = '', $aria = '', $textare
                             <div id="help_proxy" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('If you got a proxy (e.g. EZproxy) to allow patrons outside of your ip range access then set the base url here (e.g. http://www.umm.uni-heidelberg.de/ezproxy/login.auth?url=).') ?></span></div>
                         <input type="checkbox" name="cfg[prefs][show_dl_button]" <?php echo frm_checked($cfg->prefs->show_dl_button) ?> aria-describedby="help_show_dl_button">
                             <label for="cfg[prefs][show_dl_button]"><?php echo __('Enable button for direct download?') ?></label><br />
-                            <div id="help_show_dl_button" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('If you enable this a button for directly downloading a article\'s pdf file (and onyl pdf currently) is displayed in the toc for a journal. This only applies to publishers where we were able to figure out the link to do that. The idea is to not force a user to the publishers landing page.') ?></span></div>
+                            <div id="help_show_dl_button" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('If you enable this a button for directly downloading a article\'s pdf file (and only pdf currently) is displayed in the toc for a journal. This only applies to publishers where we were able to figure out the link to do that. The idea is to not force a user to the publishers landing page.') ?></span></div>
                         <label for="cfg[prefs][sfx]"><?php echo __('SFX Service') ?></label>
                             <input type="text" name="cfg[prefs][sfx]" value="<?php echo $cfg->prefs->sfx ?>" aria-describedby="help_sfx" />
                             <div id="help_sfx" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('Your sfx baseurl (e.g. http://sfx.gbv.de/sfx_tuhh). Currently used as alternative for the direct download button.') ?></span></div>
@@ -539,7 +539,7 @@ function frm_input_translatable($name, $value, $label = '', $aria = '', $textare
                                 <select id="multiple_languages" multiple data-prompt="<?php echo __('Enable languages') ?>" name="cfg[prefs][languages][]" aria-describedby="help_languages">
                                     <?php echo $langs_frm; ?>
                                 </select>
-                                <div id="help_languages" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('Enable all languages that should be available to visitors. For alle actived languages some fields are translatable in this admin menu. If you activate a new language, the translation fields will only show up, after you saved the settings and reload the page.') ?></span></div>
+                                <div id="help_languages" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('Enable all languages that should be available to visitors. For alle activated languages some fields are translatable in this admin menu. If you activate a new language, the translation fields will only show up, after you saved the settings and reload the page.') ?></span></div>
                         </div>
                     </div>
                 </fieldset>
@@ -579,7 +579,7 @@ function frm_input_translatable($name, $value, $label = '', $aria = '', $textare
                         <?php echo frm_input_translatable('cfg_ary[translations][meta_journalHP]',  $cfg->translations['meta_journalHP'], __('Meta Button: Journal Homepage'), 'help_trans_meta_journalHP') ?>
                         <div id="help_trans_meta_journalHP" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('The button linking to the journal\'s homepage (see journals.csv column 16).') ?></span></div>
                         <?php echo frm_input_translatable('cfg_ary[translations][meta_inst_service]',  $cfg->translations['meta_inst_service'], __('Library service'), 'help_trans_meta_inst_service') ?>
-                        <div id="help_trans_meta_inst_service" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('The link to you catalogue/service witht the journal\'s issn appended.') ?></span></div>
+                        <div id="help_trans_meta_inst_service" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('The link to you catalogue/service with the journal\'s issn appended.') ?></span></div>
                 </fieldset>
                 <fieldset>
                     <legend><?php echo __('Translations: Other') ?></legend>
@@ -604,7 +604,7 @@ function frm_input_translatable($name, $value, $label = '', $aria = '', $textare
                     <legend><?php echo __('Api: General Settings') ?></legend>
                         <input type="checkbox" name="cfg[api][all][articleLink]" <?php echo frm_checked($cfg->api->all->articleLink) ?> aria-describedby="help_articleLink" />
                             <label for="cfg[api][all][articleLink]"><?php echo __('Make articles in tocs a clickable link') ?></label>
-                            <div id="help_articleLink" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('If people access JournalTouch from somewhere where they have no access to the licenced ressources, disabling the linking might be an option. They can still add the items to the basket and order them (or fetch them in the library themselves).') ?></span></div>
+                            <div id="help_articleLink" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('If people access JournalTouch from somewhere where they have no access to the licensed ressources, disabling the linking might be an option. They can still add the items to the basket and order them (or fetch them in the library themselves).') ?></span></div>
                         <label for="cfg[api][all][is_new_days]"><?php echo __('Mark issue for how many days as new?') ?></label>
                             <input type="text" name="cfg[api][all][is_new_days]" value="<?php echo $cfg->api->all->is_new_days ?>" aria-describedby="help_is_new_days" />
                             <div id="help_is_new_days" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('If a new issue is found on the update (use a daily cron to keep track) it is marked as new for as many days as specified here. You might think it\'d be much cooler if the journal\'s publishing frequency would be used. Well, we think so too, but where to get it - or who would want to enter it by hand. Anyway, if you got a premium account and use the data for the live view (see below) you can ignore this setting.)') ?></span></div>
@@ -776,7 +776,7 @@ function frm_input_translatable($name, $value, $label = '', $aria = '', $textare
 
                         <input type="checkbox" name="cfg[kiosk][policy_NoSendLib]" <?php echo frm_checked($cfg->kiosk->policy_NoSendLib) ?> aria-describedby="help_kiosk_policy_NoSendLib" />
                             <label for="cfg[kiosk][policy_NoSendLib]"><?php echo (__('Disable').' "'.__('Send to library to get PDFs').'"') ?>?</label><br />
-                            <div id="help_kiosk_policy_NoSendLib" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('Don\'t allow users to send request for PDFs to library on kiosk pc\'s. To completly disable this feature, go to "Settings"') ?></span></div>
+                            <div id="help_kiosk_policy_NoSendLib" class="tooltip" role="tooltip" aria-hidden="true"><span><?php echo __('Don\'t allow users to send request for PDFs to library on kiosk pc\'s. To completely disable this feature, go to "Settings"') ?></span></div>
                 </fieldset>
                 <fieldset>
                     <legend><?php echo __('Policies: Main page') ?></legend>

--- a/admin/updateTocs.php
+++ b/admin/updateTocs.php
@@ -39,7 +39,7 @@ if ($btn_cache) {
             $i++;
         }
     }
-    $del_message = "<strong>Sucess: $i files deleted</strong>";
+    $del_message = "<strong>Success: $i files deleted</strong>";
 }
 ?>
 

--- a/admin/upgrade/class.JtUpgrader.php
+++ b/admin/upgrade/class.JtUpgrader.php
@@ -291,9 +291,9 @@ class JtUpgrader {
 
                 $status = copy($src_filepath, $dest_filepath);
 
-                // Sucessfully copied?
+                // Successfully copied?
                 if ($status) {
-                    $status_log .=  "<p>Sucessfully copied $src_filepath to $dest_filepath<br>";
+                    $status_log .=  "<p>Successfully copied $src_filepath to $dest_filepath<br>";
                 } else {
                     $status_log .=  "FAILED copying $src_filepath to $dest_filepath<br><strong>UPGRADE STOPPED</strong><br>";
                     break;
@@ -302,9 +302,9 @@ class JtUpgrader {
                 // Ok copied, now delete src
                 $status = unlink($src_filepath);
 
-                // Sucessfully deleted?
+                // Successfully deleted?
                 if ($status) {
-                    $status_log .=  "Sucessfully deleted $src_filepath</p>";
+                    $status_log .=  "Successfully deleted $src_filepath</p>";
                 }
                 // Otherwise break loop
                 else {
@@ -357,9 +357,9 @@ class JtUpgrader {
             // Folder empty? Now remove it
             $status = rmdir($folder_path);
 
-            // Sucessfully deleted?
+            // Successfully deleted?
             if ($status) {
-                $status_log .=  "Sucessfully deleted $folder_path<br>";
+                $status_log .=  "Successfully deleted $folder_path<br>";
             }
             // Otherwise break loop
             else {

--- a/checkout.php
+++ b/checkout.php
@@ -247,7 +247,7 @@ if(isset($_POST['mailer']))
 
                 <div class="row sendArticlesToLib sendArticlesToUser">
 <?php
-// if GetUsers failed or was turned off, allow entering an adress
+// if GetUsers failed or was turned off, allow entering an address
 if ($users === false) {
     $placeholder = ($cfg->mail->domain) ? __('your username') : __('Your e-mail');
     $postfix     = ($cfg->mail->domain) ? '@'.$cfg->mail->domain : '';

--- a/index.php
+++ b/index.php
@@ -106,7 +106,7 @@ $journalUpdates = $lister->getJournalUpdates();
 <?php
 /* use filter translations from the config file */
 $filters_used = array_column($journals, 'filter');   // Get only the filters set for all journals
-$filters_used = array_count_values($filters_used);   // Count occurences of each filter
+$filters_used = array_count_values($filters_used);   // Count occurrences of each filter
 
 // Get all filters that are actually used in journals.csv
 foreach ($filters_used as $filter_key => $filter_count) {

--- a/js/local/conduit.js
+++ b/js/local/conduit.js
@@ -209,7 +209,7 @@ function start_screensaver(srcDiv) {
         });
     };
     /**
-     * [Animated screensaver] Caluclate random new position for div
+     * [Animated screensaver] Calculate random new position for div
      * Credits go to Lee at https://stackoverflow.com/a/10386178
      * @return array with new coordinates
      */
@@ -224,7 +224,7 @@ function start_screensaver(srcDiv) {
         return [nh,nw];
     }
     /**
-     * [Animated screensaver] Caluclate random new speed for animation
+     * [Animated screensaver] Calculate random new speed for animation
      * Credits go to Lee at https://stackoverflow.com/a/10386178
      * @return float with speed value
      */

--- a/js/local/simpleCart.custom.js
+++ b/js/local/simpleCart.custom.js
@@ -177,7 +177,7 @@
 					var info		= values || {},
 						newItem		= new simpleCart.Item(info),
 						addItem 	= true,
-						// optionally supress event triggers
+						// optionally suppress event triggers
 						quiet 		= opt_quiet === true ? opt_quiet : false,
 						oldItem;
 


### PR DESCRIPTION
All of them were found and fixed by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>