### PR TITLE
minor fixes for new installations

### DIFF
--- a/data/upgraded/ver_0.4
+++ b/data/upgraded/ver_0.4
@@ -1,2 +1,0 @@
-Version 0.4
-Blabla or move these files yourself. And delete these folder yourself.


### PR DESCRIPTION
Fixes to minor bugs which only apply to new installations.
The patches
  * add data/config/.gitkeep
  * remove data/upgraded/ver_*
While the folder is required for new installations, the ver_* upgrade tags are unneeded.
